### PR TITLE
Native reference mutability and explicitness

### DIFF
--- a/.devcontainer/default/VSCode/launch.json
+++ b/.devcontainer/default/VSCode/launch.json
@@ -1,0 +1,17 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug MLIR Bindings Support Test",
+      "program": "${workspaceFolder}/build/circel/bin/mlir-bindings-support-test",
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "Build Circel"
+    }
+  ]
+}

--- a/.devcontainer/default/VSCode/tasks.json
+++ b/.devcontainer/default/VSCode/tasks.json
@@ -6,7 +6,8 @@
       "label": "Build Circel",
       "command": "build",
       "targets": [
-        "CircelJNI"
+        "CircelJNI",
+        "mlir-bindings-support-test"
       ],
       "group": {
         "kind": "build",

--- a/.devcontainer/default/devcontainer.json
+++ b/.devcontainer/default/devcontainer.json
@@ -25,7 +25,8 @@
         "llvm-vs-code-extensions.vscode-mlir",
         "ms-vscode.cmake-tools",
         "scalameta.metals",
-        "timonwong.shellcheck"
+        "timonwong.shellcheck",
+        "vadimcn.vscode-lldb"
       ]
     }
   }

--- a/mlir/circel/include/circel/Bindings/Support/NativeReference.h
+++ b/mlir/circel/include/circel/Bindings/Support/NativeReference.h
@@ -79,7 +79,7 @@ public:
       storage->storedDestructor(storage);
   }
 
-  void *getRetainedOpaqueReference() {
+  void *getRetainedOpaqueReference() const {
     storage->referenceCount++;
     return reinterpret_cast<void *>(storage);
   }
@@ -94,32 +94,32 @@ public:
 };
 
 namespace detail {
-template <typename T> class TypedNativeReference : public AnyNativeReference {
+template <typename T> class NativeReferenceImpl : public AnyNativeReference {
 
 protected:
-  explicit TypedNativeReference(void *opaqueReference)
+  explicit NativeReferenceImpl(void *opaqueReference)
       : AnyNativeReference(opaqueReference) {
     assertStorageTypeMatches<T>();
   }
 
-  explicit TypedNativeReference(Storage<T> *storage)
+  explicit NativeReferenceImpl(Storage<T> *storage)
       : AnyNativeReference(storage) {}
 
   template <typename... Args>
-  static TypedNativeReference<T> create(Args &&...args) {
-    return TypedNativeReference<T>(
+  static NativeReferenceImpl<T> create(Args &&...args) {
+    return NativeReferenceImpl<T>(
         new mlir::bindings::AnyNativeReference::Storage<T>(
             std::forward<Args>(args)...));
   }
 
-  static TypedNativeReference<T> getFromOpaqueReference(void *opaqueReference) {
-    auto reference = TypedNativeReference<T>(opaqueReference);
+  static NativeReferenceImpl<T> getFromOpaqueReference(void *opaqueReference) {
+    auto reference = NativeReferenceImpl<T>(opaqueReference);
     reference.template assertStorageTypeMatches<T>();
     return reference;
   }
 
 public:
-  TypedNativeReference(const TypedNativeReference &source)
+  NativeReferenceImpl(const NativeReferenceImpl &source)
       : AnyNativeReference(source) {}
 
   T *operator->() const { return getPointerToValue<T>(); }
@@ -128,7 +128,7 @@ public:
 } // namespace detail
 
 template <typename T>
-class NativeReference : public detail::TypedNativeReference<T> {};
+class NativeReference : public detail::NativeReferenceImpl<T> {};
 
 } // namespace bindings
 } // namespace mlir

--- a/mlir/circel/test/Bindings/Support/NativeReferenceTest.cpp
+++ b/mlir/circel/test/Bindings/Support/NativeReferenceTest.cpp
@@ -1,48 +1,76 @@
 // RUN: mlir-bindings-support-test 2>&1 | FileCheck %s
 
 #include "circel/Bindings/Support/NativeReference.h"
+#include "NativeReferenceTest.h"
 
+#include <cassert>
 #include <cstdint>
 #include <iostream>
+#include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/Types.h>
 #include <mlir/Support/TypeID.h>
 
 using namespace mlir::bindings;
 
-int main() {
-  static int deinitializations = 0;
-  struct DeinitializationTracker {
-    DeinitializationTracker() {}
-    ~DeinitializationTracker() { deinitializations++; }
-  };
+static int deinitializations = 0;
+TestHelper::~TestHelper() {
+  { deinitializations++; }
+}
 
+void testMutability() {
+  // CHECK-LABEL: @testMutability
+  std::cout << "@testMutability" << std::endl;
+  deinitializations = 0;
   void *opaqueReference = nullptr;
   {
-    auto reference = NativeReference<DeinitializationTracker>::create();
+    auto reference = NativeReference<TestHelper>::create();
+    opaqueReference = reference.getRetainedOpaqueReference();
+    reference->storedInt = 42;
+    // CHECK-NEXT: 42
+    std::cout << reference->storedInt << std::endl;
+  }
+  {
+    auto reference =
+        NativeReference<TestHelper>::getFromOpaqueReference(opaqueReference);
+    AnyNativeReference::releaseOpaqueReference(opaqueReference);
+    // CHECK-NEXT: 42
+    std::cout << reference->storedInt << std::endl;
+  }
+  assert(deinitializations == 1);
+}
+
+void testReferenceCounting() {
+  // CHECK-LABEL: @TestReferenceCounting
+  std::cout << "@TestReferenceCounting" << std::endl;
+  deinitializations = 0;
+  void *opaqueReference = nullptr;
+  {
+    auto reference = NativeReference<TestHelper>::create();
     opaqueReference = reference.getRetainedOpaqueReference();
 
-    // CHECK: 0
+    // CHECK-NEXT: 0
     std::cout << deinitializations << std::endl;
   }
 
-  // CHECK: 0
+  // CHECK-NEXT: 0
   std::cout << deinitializations << std::endl;
 
   {
     auto reference =
-        NativeReference<DeinitializationTracker>::getFromOpaqueReference(
-            opaqueReference);
-
-    reference.getValue();
+        NativeReference<TestHelper>::getFromOpaqueReference(opaqueReference);
 
     AnyNativeReference::releaseOpaqueReference(opaqueReference);
 
-    // CHECK: 0
+    // CHECK-NEXT: 0
     std::cout << deinitializations << std::endl;
   }
 
-  // CHECK: 1
+  // CHECK-NEXT: 1
   std::cout << deinitializations << std::endl;
+}
 
+int main() {
+  testMutability();
+  testReferenceCounting();
   return 0;
 }

--- a/mlir/circel/test/Bindings/Support/NativeReferenceTest.h
+++ b/mlir/circel/test/Bindings/Support/NativeReferenceTest.h
@@ -11,9 +11,9 @@ struct TestHelper {
 
 template <>
 class mlir::bindings::NativeReference<TestHelper>
-    : public detail::TypedNativeReference<TestHelper> {
+    : public detail::NativeReferenceImpl<TestHelper> {
 public:
-  using detail::TypedNativeReference<TestHelper>::TypedNativeReference;
-  using detail::TypedNativeReference<TestHelper>::create;
-  using detail::TypedNativeReference<TestHelper>::getFromOpaqueReference;
+  using detail::NativeReferenceImpl<TestHelper>::NativeReferenceImpl;
+  using detail::NativeReferenceImpl<TestHelper>::create;
+  using detail::NativeReferenceImpl<TestHelper>::getFromOpaqueReference;
 };

--- a/mlir/circel/test/Bindings/Support/NativeReferenceTest.h
+++ b/mlir/circel/test/Bindings/Support/NativeReferenceTest.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "circel/Bindings/Support/NativeReference.h"
+
+struct TestHelper {
+  int storedInt = 0;
+
+  TestHelper() {}
+  ~TestHelper();
+};
+
+template <>
+class mlir::bindings::NativeReference<TestHelper>
+    : public detail::TypedNativeReference<TestHelper> {
+  explicit NativeReference(
+      mlir::bindings::AnyNativeReference::Storage<TestHelper> *storage)
+      : detail::TypedNativeReference<TestHelper>(storage) {}
+
+  explicit NativeReference<TestHelper>(void *opaqueReference)
+      : detail::TypedNativeReference<TestHelper>(opaqueReference) {}
+
+public:
+  explicit NativeReference(TestHelper &&value)
+      : detail::TypedNativeReference<TestHelper>(
+            new mlir::bindings::AnyNativeReference::Storage<TestHelper>(
+                std::forward<TestHelper>(value))) {}
+
+  template <typename... Args>
+  static NativeReference<TestHelper> create(Args &&...args) {
+    return NativeReference<TestHelper>(
+        new mlir::bindings::AnyNativeReference::Storage<TestHelper>(
+            std::forward<Args>(args)...));
+  }
+
+  static NativeReference<TestHelper>
+  getFromOpaqueReference(void *opaqueReference) {
+    auto reference = NativeReference<TestHelper>(opaqueReference);
+    reference.template assertStorageTypeMatches<TestHelper>();
+    return reference;
+  }
+};

--- a/mlir/circel/test/Bindings/Support/NativeReferenceTest.h
+++ b/mlir/circel/test/Bindings/Support/NativeReferenceTest.h
@@ -12,30 +12,8 @@ struct TestHelper {
 template <>
 class mlir::bindings::NativeReference<TestHelper>
     : public detail::TypedNativeReference<TestHelper> {
-  explicit NativeReference(
-      mlir::bindings::AnyNativeReference::Storage<TestHelper> *storage)
-      : detail::TypedNativeReference<TestHelper>(storage) {}
-
-  explicit NativeReference<TestHelper>(void *opaqueReference)
-      : detail::TypedNativeReference<TestHelper>(opaqueReference) {}
-
 public:
-  explicit NativeReference(TestHelper &&value)
-      : detail::TypedNativeReference<TestHelper>(
-            new mlir::bindings::AnyNativeReference::Storage<TestHelper>(
-                std::forward<TestHelper>(value))) {}
-
-  template <typename... Args>
-  static NativeReference<TestHelper> create(Args &&...args) {
-    return NativeReference<TestHelper>(
-        new mlir::bindings::AnyNativeReference::Storage<TestHelper>(
-            std::forward<Args>(args)...));
-  }
-
-  static NativeReference<TestHelper>
-  getFromOpaqueReference(void *opaqueReference) {
-    auto reference = NativeReference<TestHelper>(opaqueReference);
-    reference.template assertStorageTypeMatches<TestHelper>();
-    return reference;
-  }
+  using detail::TypedNativeReference<TestHelper>::TypedNativeReference;
+  using detail::TypedNativeReference<TestHelper>::create;
+  using detail::TypedNativeReference<TestHelper>::getFromOpaqueReference;
 };


### PR DESCRIPTION
Updates NativeReference to allow mutation of the referenced data. Also it removes the ability to make NativeReferences to arbitrary types, instead each natively-referencable class needs to opt-in to native referencability (we can wrap this up in a macro later, and maybe add an explicit MLIR type ID for good measure). I think this is the right approach as it will minimize the creation of unintended native references that won't work well with the rest of the system (for example, a native reference to a `mlir::Attribute` that isn't contextual). Note that we aren't preventing this, just requiring an explicit declaration of the set of types that are intended to be native-referencable. 
This should also enable us to do partial-specializations in separate headers, which is a bit cleanlier. For example, we can partially-specialize `NativeReference<Contextual<mlir::{Attribute,Type}>>` alongside the declaration of `Contextual`.